### PR TITLE
Improve schema documentation and fix inconsistencies from review

### DIFF
--- a/_schema_docs/1.2/assertion-1.2.md
+++ b/_schema_docs/1.2/assertion-1.2.md
@@ -20,28 +20,33 @@ This property must be one of the following types:
 
 ## `id` (string, required)
 
-URI that links to the certificate on the viewer. Default is https://[domain]/[uid]
+URI that links to the certificate on the viewer.
 
 ## `uid` (string, required)
 
-Unique identifier, in GUID format. 1.2 changes: string pattern changed to guid
+Unique identifier, in GUID format. V1.2 change: string pattern changed to guid
 
 Additional restrictions:
 
 * Regex pattern: `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
 
-## `issuedOn` (, required)
+## `issuedOn` ([DateTime](https://openbadgespec.org/v1/schema/assertion.json#/definitions/DateTime), required)
 
 Date the the certificate JSON was created.
 
 ## `evidence` (string)
 
-Text, uri, etc. that shows evidence of the recipient's learning that the certificate represents. Can be left as an empty string if not used.
+URL of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible. V1.2 made this field optional, which is consistent with OBI spec.
 
-## `expires`
+## `expires` ([DateTime](https://openbadgespec.org/v1/schema/assertion.json#/definitions/DateTime))
 
-Date the the certificate JSON expires.
+If the achievement has some notion of expiry, this indicates a date when a badge should no longer be considered valid.
 
-## `image:signature` (ImageBase64)
+## `image:signature` (string)
 
-A base-64 encoded png image of the issuer's signature.
+Data URI; a base-64 encoded png image of the certificate's image. https://en.wikipedia.org/wiki/Data_URI_scheme
+
+Additional restrictions:
+
+* Regex pattern: `data:image/png;base64,`
+

--- a/_schema_docs/1.2/blockchain-certificate-1.2.md
+++ b/_schema_docs/1.2/blockchain-certificate-1.2.md
@@ -10,9 +10,7 @@ The schema defines the following properties:
 
 ## `@context` (JsonLdContext, required)
 
-A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain certificates contexts extend Open Badges contexts, and also define JSON-schema to validate blockchain certificates against.
-
-This should contain the Blockchain Certificates JSON LD context: [https://w3id.org/blockcerts/context](https://w3id.org/blockcerts/context).
+A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain certificates contexts extend Open Badges contexts, and also define JSON-schema to validate blockchain certificates. This should contain the Blockchain Certificates JSON LD context: https://w3id.org/blockcerts/context
 
 This property must be one of the following types:
 
@@ -30,8 +28,8 @@ This property must be one of the following types:
 
 ## `document` (CertificateDocument, required)
 
-[CertificateDocument](/docs/schema/v1_2/document/)
+[CertificateDocument](/docs/schema/1_2/document/)
 
 ## `receipt` (BlockchainReceipt, required)
 
-[BlockchainReceipt](/docs/schema/v1_2/receipt/)
+[BlockchainReceipt](/docs/schema/1_2/receipt/)

--- a/_schema_docs/1.2/blockchain-certificate-1.2.md
+++ b/_schema_docs/1.2/blockchain-certificate-1.2.md
@@ -10,7 +10,9 @@ The schema defines the following properties:
 
 ## `@context` (JsonLdContext, required)
 
-A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain certificates contexts extend Open Badges contexts, and also define JSON-schema to validate blockchain certificates. This should contain the Blockchain Certificates JSON LD context: https://w3id.org/blockcerts/context
+A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain certificates contexts extend Open Badges contexts, and also define JSON-schema to validate blockchain certificates.
+
+This should contain the Blockchain Certificates JSON LD context: [https://w3id.org/blockcerts/context](https://w3id.org/blockcerts/context).
 
 This property must be one of the following types:
 

--- a/_schema_docs/1.2/blockchain-receipt-1.2.md
+++ b/_schema_docs/1.2/blockchain-receipt-1.2.md
@@ -9,6 +9,15 @@ Provides evidence of the certificate on the blockchain, using the chainpoint v2 
 
 The schema defines the following properties:
 
+## `@type` (JsonLdType, required)
+
+A type or an array of types that the receipt object represents. The first or only item should be 'BlockchainReceipt', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'BlockchainReceipt'
+
+This property must be one of the following types:
+
+* `string`
+* `array`
+
 ## `type` (string, required)
 
 type of hash. Currently the only supported hash type is SHA256, with chainpoint type ChainpointSHA256v2.

--- a/_schema_docs/1.2/certificate-1.2.md
+++ b/_schema_docs/1.2/certificate-1.2.md
@@ -10,7 +10,7 @@ The schema defines the following properties:
 
 ## `@type` (JsonLdType, required)
 
-A type or an array of types that the assertion object represents. The first or only item should be 'Certificate', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Assertion'
+A type or an array of types that the certificate represents. The first or only item should be 'Certificate', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Certificate'
 
 This property must be one of the following types:
 
@@ -41,11 +41,11 @@ Additional restrictions:
 
 ## `issuer` (Issuer, required)
 
-([Issuer, required](/docs/schema/v1_2/issuer/))
+([Issuer, required](/docs/schema/1_2/issuer/))
 
 ## `language` (string)
 
-Represents the ieft language and ieft country codes. Format is [ieft_language]-[IEFT_COUNTRY]. 1.2 changes: this field is optional
+Represents the ieft language and ieft country codes. Format is [ieft_language]-[IEFT_COUNTRY]. V1.2 changes: this field is optional
 
 Additional restrictions:
 
@@ -53,7 +53,7 @@ Additional restrictions:
 
 ## `subtitle` (string)
 
-Subtitle of the certificate. 1.2 changes: this type is now string, and this field is optional
+Subtitle of the certificate. V1.2 changes: this type is now string, and this field is optional
 
 ## `title` (string, required)
 

--- a/_schema_docs/1.2/certificate-document-1.2.md
+++ b/_schema_docs/1.2/certificate-document-1.2.md
@@ -17,20 +17,37 @@ This property must be one of the following types:
 * `string`
 * `array`
 
-
 ## `certificate` (Certificate, required)
 
-[Certificate](/docs/schema/v1_2/certificate/)
+[Certificate](/docs/schema/1_2/certificate/)
 
 ## `assertion` (Assertion, required)
 
-[Assertion](/docs/schema/v1_2/assertion/)
+[Assertion](/docs/schema/1_2/assertion/)
 
 ## `verify` (VerificationObject, required)
 
+## `recipient` (Recipient, required)
+
+---
+
+# Sub Schemas
+
+The schema defines the following additional types:
+
+## `VerificationObject` (object)
+
+V1.2 notice: the Blockchain Certificates VerificationObject will change in the next schema version to be consistent with OBI VerificationObjects. This work is in progress.
+
 Properties of the `VerificationObject` object:
 
-### `type` (string, enum)
+### `attribute-signed` (string, required)
+
+Name of the attribute in the json that is signed by the issuer's private key. Default is 'uid', referring to the uid attribute.
+
+### `type` (string, enum, required)
+
+Name of the signing method. Default is 'ECDSA(secp256k1)', referring to the Blockchain Certificates method of signing messages with the issuer's private key.
 
 This element must be one of the following enum values:
 
@@ -38,9 +55,11 @@ This element must be one of the following enum values:
 * `signed`
 * `ECDSA(secp256k1)`
 
-### `url` (string)
+### `signer` (string, required)
 
-## `recipient` (Recipient, required)
+URI where issuer's public key is presented. Default is https://[domain]/keys/[org-abbr]-certs-public-key.asc
+
+## `Recipient` (object)
 
 Properties of the `Recipient` object:
 
@@ -60,7 +79,7 @@ Type of value in the identity field. Default is 'email'.
 
 ### `hashed` (boolean, required)
 
-Describes if the value in the identity field is hashed or not. We strongly recommend that the issuer hash the identy to protect the recipient. Backcompatible change to allow 2 types that occurred in the wild before proper validation.
+Describes if the value in the identity field is hashed or not. We strongly recommend that the issuer hash the identy to protect the recipient.
 
 ### `salt` (string)
 

--- a/_schema_docs/1.2/issuer-1.2.md
+++ b/_schema_docs/1.2/issuer-1.2.md
@@ -8,16 +8,14 @@ Extends the Open Badges Issuer Schema for certificates on the blockchain
 
 The schema defines the following properties:
 
-
 ## `@type` (JsonLdType, required)
 
-A type or an array of types that the assertion object represents. The first or only item should be 'Issuer', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Assertion'
+A type or an array of types that the issuer object represents. The first or only item should be 'Issuer', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Issuer'
 
 This property must be one of the following types:
 
 * `string`
 * `array`
-
 
 ## `id` (string, required)
 
@@ -45,5 +43,7 @@ The URL of the issuer's website or homepage
 A text description of the issuing organization
 
 ## `email` (string)
+
+Contact address for the individual or organization.
 
 ## `revocationList` (string)

--- a/_schema_docs/1.2/issuer-keys-1.2.md
+++ b/_schema_docs/1.2/issuer-keys-1.2.md
@@ -1,0 +1,47 @@
+---
+title: Issuer Keys Schema Version 1.2
+sitemap: true
+permalink: /docs/schema/1_2/issuer_keys/
+---
+
+The schema defines the following properties:
+
+# `issuerKeys` (array, required)
+
+list of issuer keys, listed in descending date order (most recent first). V1.2 change: renamed from issuer_key, added optional invalidated field.
+
+The object is an array with all elements of the type `object`.
+
+The array object has the following properties:
+
+## `date` (string, required)
+
+ISO-8601 formatted date time the key was activated.
+
+## `key` (string, required)
+
+Bitcoin address (compressed public key, usually 24 characters) that the issuer uses to issue the certificates.
+
+## `invalidated` (string)
+
+Optional ISO-8601 formatted date time the key was invalidated.
+
+# `revocationKeys` (array, required)
+
+list of revocation keys, listed in descending date order (most recent first). V1.2 changes: renamed from revocation_key, added optional invalidated field.
+
+The object is an array with all elements of the type `object`.
+
+The array object has the following properties:
+
+## `date` (string, required)
+
+ISO-8601 formatted date time the key was activated.
+
+## `key` (string, required)
+
+Bitcoin address (compressed public key, usually 24 characters) that the issuer uses to revoke the certificates.
+
+## `invalidated` (string)
+
+Optional ISO-8601 formatted date time the key was invalidated.

--- a/schema/1.2/assertion-1.2.json
+++ b/schema/1.2/assertion-1.2.json
@@ -18,11 +18,6 @@
           }
         }
       ]
-    },
-    "ImageBase64": {
-      "type": "string",
-      "description": "A base-64 encoded png image of the issuer's logo.",
-      "pattern": "data:image/png;base64,"
     }
   },
   "properties": {
@@ -32,12 +27,12 @@
     "id": {
       "type": "string",
       "format": "uri",
-      "description": "URI that links to the certificate on the viewer. Default is https://[domain]/[uid]"
+      "description": "URI that links to the certificate on the viewer."
     },
     "uid": {
       "type": "string",
       "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-      "description": "Unique identifier, in GUID format. 1.2 changes: string pattern changed to guid"
+      "description": "Unique identifier, in GUID format. V1.2 change: string pattern changed to guid"
     },
     "issuedOn": {
       "$ref": "https://openbadgespec.org/v1/schema/assertion.json#/definitions/DateTime",
@@ -46,15 +41,17 @@
     "evidence": {
       "type": "string",
       "format": "uri",
-      "description": "Text, uri, etc. that shows evidence of the recipient's learning that the certificate represents. Can be left as an empty string if not used."
+      "description": "URL of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible. V1.2 made this field optional, which is consistent with OBI spec."
     },
     "expires": {
       "$ref": "https://openbadgespec.org/v1/schema/assertion.json#/definitions/DateTime",
-      "description": "Date the the certificate JSON expires."
+      "description": "If the achievement has some notion of expiry, this indicates a date when a badge should no longer be considered valid."
     },
     "image:signature": {
-      "$ref": "#/definitions/ImageBase64",
-      "description": "A base-64 encoded png image of the issuer's signature."
+      "type": "string",
+      "pattern": "data:image/png;base64,",
+      "description": "Data URI; a base-64 encoded png image of the certificate's image. https://en.wikipedia.org/wiki/Data_URI_scheme"
+
     }
   },
   "required": [

--- a/schema/1.2/blockchain-certificate-1.2.json
+++ b/schema/1.2/blockchain-certificate-1.2.json
@@ -6,7 +6,7 @@
   "type": "object",
   "definitions": {
     "JsonLdContext": {
-      "description": "A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain certificates contexts extend Open Badges contexts, and also define JSON-schema to validate blockchain certificates against.",
+      "description": "A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain certificates contexts extend Open Badges contexts, and also define JSON-schema to validate blockchain certificates. This should contain the Blockchain Certificates JSON LD context: https://w3id.org/blockcerts/context",
       "oneOf": [
         {
           "type": "string"

--- a/schema/1.2/certificate-1.2.json
+++ b/schema/1.2/certificate-1.2.json
@@ -55,12 +55,12 @@
     },
     "language": {
       "type": "string",
-      "description": "Represents the ieft language and ieft country codes. Format is [ieft_language]-[IEFT_COUNTRY]. 1.2 changes: this field is optional",
+      "description": "Represents the ieft language and ieft country codes. Format is [ieft_language]-[IEFT_COUNTRY]. V1.2 changes: this field is optional",
       "pattern": "[a-z]{2}-[A-Z]{2}"
     },
     "subtitle": {
       "type": "string",
-      "description": "Subtitle of the certificate. 1.2 changes: this type is now string, and this field is optional"
+      "description": "Subtitle of the certificate. V1.2 changes: this type is now string, and this field is optional"
     },
     "title": {
       "type": "string",

--- a/schema/1.2/certificate-document-1.2.json
+++ b/schema/1.2/certificate-document-1.2.json
@@ -25,26 +25,34 @@
     "Assertion": {
       "$ref": "http://www.blockcerts.org/schema/1.2/assertion-1.2.json"
     },
-    "Issuer": {
-      "$ref": "http://www.blockcerts.org/schema/1.2/issuer-1.2.json"
-    },
     "VerificationObject": {
       "type": "object",
+      "description": "V1.2 notice: the Blockchain Certificates VerificationObject will change in the next schema version to be consistent with OBI VerificationObjects. This work is in progress.",
       "properties": {
+        "attribute-signed": {
+          "type": "string",
+          "description": "Name of the attribute in the json that is signed by the issuer's private key. Default is 'uid', referring to the uid attribute."
+        },
         "type": {
-          "title": "VerificationType",
           "type": "string",
           "enum": [
             "hosted",
             "signed",
             "ECDSA(secp256k1)"
-          ]
+          ],
+          "description": "Name of the signing method. Default is 'ECDSA(secp256k1)', referring to the Blockchain Certificates method of signing messages with the issuer's private key."
         },
-        "url": {
+        "signer": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI where issuer's public key is presented. Default is https://[domain]/keys/[org-abbr]-certs-public-key.asc"
         }
-      }
+      },
+      "required": [
+        "attribute-signed",
+        "type",
+        "signer"
+      ]
     },
     "Recipient": {
       "type": "object",
@@ -66,7 +74,7 @@
         },
         "hashed": {
           "type": "boolean",
-          "description": "Describes if the value in the identity field is hashed or not. We strongly recommend that the issuer hash the identy to protect the recipient. Backcompatible change to allow 2 types that occurred in the wild before proper validation."
+          "description": "Describes if the value in the identity field is hashed or not. We strongly recommend that the issuer hash the identy to protect the recipient."
         },
         "salt": {
           "type": "string",

--- a/schema/1.2/context.json
+++ b/schema/1.2/context.json
@@ -69,10 +69,6 @@
       "givenName": {
         "@id": "schema:givenName"
       },
-      "signer": {
-        "@id": "bc:signer",
-        "@type": "@id"
-      },
       "attribute-signed": {
         "@id": "bc:attribute-signed"
       },

--- a/schema/1.2/issuer-1.2.json
+++ b/schema/1.2/issuer-1.2.json
@@ -56,7 +56,8 @@
     },
     "email": {
       "type": "string",
-      "format": "email"
+      "format": "email",
+      "description": "Contact address for the individual or organization."
     },
     "revocationList": {
       "type": "string",

--- a/schema/1.2/issuer-keys-1.2.json
+++ b/schema/1.2/issuer-keys-1.2.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://www.blockcerts.org/schema/1.2/issuer-keys-1.2.json",
+  "type": "object",
+  "properties": {
+    "issuerKeys": {
+      "type": "array",
+      "description": "list of issuer keys, listed in descending date order (most recent first). V1.2 change: renamed from issuer_key, added optional invalidated field.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO-8601 formatted date time the key was activated."
+          },
+          "key": {
+            "type": "string",
+            "description": "Bitcoin address (compressed public key, usually 24 characters) that the issuer uses to issue the certificates."
+          },
+          "invalidated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Optional ISO-8601 formatted date time the key was invalidated."
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "date",
+          "key"
+        ]
+      }
+    },
+    "revocationKeys": {
+      "type": "array",
+      "description": "list of revocation keys, listed in descending date order (most recent first). V1.2 changes: renamed from revocation_key, added optional invalidated field.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO-8601 formatted date time the key was activated."
+          },
+          "key": {
+            "type": "string",
+            "description": "Bitcoin address (compressed public key, usually 24 characters) that the issuer uses to revoke the certificates."
+          },
+          "invalidated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Optional ISO-8601 formatted date time the key was invalidated."
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "date",
+          "key"
+        ]
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "issuerKeys",
+    "revocationKeys"
+  ]
+}


### PR DESCRIPTION
- Naming consistency in issuer key schema. This is safe because there are no current dependencies
- VerificationObject didn't reflect the contexts. Didn't notice because the fields were not required.
- Improved documentation, especially where v1.2 updates happened or where we differ from OBI
