### PR TITLE
Downie slackin part two

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -79,6 +79,7 @@
             </div>
 
             <a href="/guide/" class="button button--border-white">Learn More</a>
+            <a href="https://blockcerts-slackin.herokuapp.com" class="button button--border-white">Join Slack</a>
           </div>
         </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,7 +33,6 @@
               <li class="menu__item"><a href="/guide/" class="menu__link">Guide</a></li>
               <li class="menu__item"><a href="/about.html" class="menu__link">About</a></li>
               <li class="menu__item"><a href="https://github.com/blockchain-certificates" class="menu__link">Github</a></li>
-              <li class="menu__item"><a href="https://blockcerts-slackin.herokuapp.com/" class="menu__link">Slack</a></li>
             </ul>
             <ul class="social">
               <li class="social__item social__item--left_margin"><a href="https://twitter.com/Blockcerts" title="Say hello in Twitter!" class="social__link social__link--twitter"></a></li>
@@ -59,7 +58,6 @@
                 <li class="header__menu_item"><a href="/guide/" class="header__menu_link header__menu_link--white">Guide</a></li>
                 <li class="header__menu_item"><a href="/about.html" class="header__menu_link header__menu_link--white">About</a></li>
                 <li class="header__menu_item"><a href="https://github.com/blockchain-certificates" class="header__menu_link header__menu_link--white"><img src="/assets/img/icons/github.png" class="cover__img--16" style="width: 18px; top: -2px; position: relative; margin-right: 2px;">&nbsp;Github</a></li>
-                <li class="header__menu_item"><script async defer src="https://blockcerts-slackin.herokuapp.com/slackin.js"></script></li>
               </ul>
               <button type="button" data-menu-index="01" class="header__burger_button js-open-menu header__item--mobile"></button>
 

--- a/about.html
+++ b/about.html
@@ -14,7 +14,7 @@ layout: default
 
         The goal of this community is to create technical resources that other developers can utilize in their own projects. Rather than independently developing custom implementations, let’s work together to build an interoperable future.</p>
 
-        For more information about this project, to express your support, or to request an invitation to the <a href="https://blockcerts.slack.com/">developer slack team</a>, please get in touch: info@blockcerts.org</p>
+        For more information about this project <a href="https://blockcerts-slackin.herokuapp.com">join the conversation on Slack</a> or <a href="mailto:info@blockcerts.org">email info@blockcerts.org</a></p>
       </span>
     </div>
   </div>


### PR DESCRIPTION
Incorporates @cjagers' feedback. This removes the slack button/link from the nav and instead places a link prominently on the home page & in the about page.

/fyi: @kimdhamilton 