### PR TITLE
Update issuer-testnet.json

### DIFF
--- a/samples/2.0/issuer-testnet.json
+++ b/samples/2.0/issuer-testnet.json
@@ -7,6 +7,7 @@
   "id": "https://www.blockcerts.org/samples/2.0/issuer-testnet.json",
   "name": "University of Learning",
   "url": "https://www.issuer.org",
+  "introductionURL": "https://www.issuer.org/intro/",
   "publicKey": [
     {
       "id": "ecdsa-koblitz-pubkey:msBCHdwaQ7N2ypBYupkp6uNxtr9Pg76imj",


### PR DESCRIPTION
added the missing introductionURL for works with blockcerts app