### PR TITLE
Adding Blockcerts schema 2.1.

### DIFF
--- a/guide/schemas-2.1.md
+++ b/guide/schemas-2.1.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+sitemap: false
+redirect_to:  https://github.com/blockchain-certificates/cert-schema/blob/master/docs/schemas-2.1.md
+---

--- a/schema/2.1/context.json
+++ b/schema/2.1/context.json
@@ -1,0 +1,68 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "bc": "https://w3id.org/blockcerts#",
+    "obi": "https://w3id.org/openbadges#",
+    "cp": "https://w3id.org/chainpoint#",
+    "schema": "http://schema.org/",
+    "sec": "https://w3id.org/security#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    
+    "MerkleProof2017": "sec:MerkleProof2017",
+    
+    "RecipientProfile": "bc:RecipientProfile",
+    "SignatureLine": "bc:SignatureLine",
+    "MerkleProofVerification2017": "bc:MerkleProofVerification2017",
+    
+    "recipientProfile": "bc:recipientProfile",
+    "signatureLines": "bc:signatureLines",
+    "introductionUrl": { "@id": "bc:introductionUrl", "@type": "@id" },
+    
+    "subtitle": "bc:subtitle",
+    
+    "jobTitle": "schema:jobTitle",
+
+    "expires": {
+      "@id": "sec:expiration",
+      "@type": "xsd:dateTime"
+    },
+    "revoked": {
+      "@id": "obi:revoked",
+      "@type": "xsd:boolean"
+    },
+    "CryptographicKey": "sec:Key",
+    "signature": "sec:signature",
+    "verification": {
+      "@id": "obi:verify",
+      "@type": "@id"
+    },
+    "publicKey": {
+      "@id": "sec:publicKey",
+      "@type": "@id"
+    },
+
+    "BTCOpReturn": "cp:BTCOpReturn",
+    "targetHash": "cp:targetHash",
+    "merkleRoot": "cp:merkleRoot",
+    "proof": "cp:proof",
+    "anchors": "cp:anchors",
+    "sourceId": "cp:sourceId",
+    "right": "cp:right",
+    "left": "cp:left"
+  },
+  "obi:validation": [
+    {
+      "obi:validatesType": "RecipientProfile",
+      "obi:validationSchema": "https://w3id.org/blockcerts/schema/2.1/recipientSchema.json"
+    },
+    {
+      "obi:validatesType": "SignatureLine",
+      "obi:validationSchema": "https://w3id.org/blockcerts/schema/2.1/signatureLineSchema.json"
+    },
+    {
+      "obi:validatesType": "MerkleProof2017",
+      "obi:validationSchema": "https://w3id.org/blockcerts/schema/2.1/merkleProof2017Schema.json"
+    }
+  ]
+}

--- a/schema/2.1/issuerSchema.json
+++ b/schema/2.1/issuerSchema.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "IssuerProfile schema",
+  "description": "Blockcerts 2.1 Issuer Identification (Profile) schema. Extends https://w3id.org/openbadges#Profile, a type that is embedded in an Open Badge and/or hosted at an issuer URI. Blockcerts specializes the Issuer Profile type into 2 schemas: the core that is embedded in the certificate (which matches the Open Badges Profile type), and one that is to be hosted at an issuer URI, to support blockchain verification of claims. This schema describes the latter. The issuer-hosted Profile is used in the Blockcerts verification process to look up the current list of public keys claimed by the issuer. This also defines an `introductionURL` which may be used by recipients (or software agents) to submit an introduction to the issuer. ",
+  "type": "object",
+  "definitions": {
+    "JsonLdContext": {
+      "description": "A link to a valid JSON-LD context, or array of JSON-LD contexts",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "array"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "JsonLdType": {
+      "description": "A type or an array of types defined in a referenced JSON-LD context.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "ImageUri": {
+      "description": "An image representative of the entity. In Blockcerts this is typically a data URI embedded as a base-64 encoded PNG image, but it may also be a URI where the image may be found.",
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^data:"
+        },
+        {
+          "type": "string",
+          "format": "uri"
+        }
+      ]
+    },
+    "DateTime": {
+      "description":  "ISO 8601 datetime",
+      "type": "string"
+    },
+    "CryptographicKey": {
+      "description": "Defined by https://web-payments.org/vocabs/security#Key",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^ecdsa-koblitz-pubkey:",
+          "description": "Issuer public key or blockchain address IRI with `<scheme>:` prefix. For Bitcoin transactions, this would be the issuer public address prefixed with `ecdsa-koblitz-pubkey:`; e.g. `ecdsa-koblitz-pubkey:14RZvYazz9H2DC2skBfpPVxax54g4yabxe`"
+        },
+        "created": {
+          "$ref": "#/definitions/DateTime"
+        },
+        "expires": {
+          "$ref": "#/definitions/DateTime"
+        },
+        "revoked": {
+          "$ref": "#/definitions/DateTime"
+        }
+      },
+      "required": [
+        "id",
+        "created"
+      ]
+    },
+    "Profile": {
+      "$id": "#profile",
+      "description": "Defined by https://w3id.org/openbadges#Profile. This type is used in certificates, and in the issuer-hosted identification page. The minimal set of properties required in the certificate are `id` and `type`. In this case, additional issuer-identification properties are assumed to be available at the issuer-hosted identification page.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri",
+          "description": "Defined by `id` property of https://w3id.org/openbadges#Profile"
+        },
+        "type": {
+          "$ref": "#/definitions/JsonLdType",
+          "description": "Defined by `type` property of https://w3id.org/openbadges#Profile"
+        },
+        "name": {
+          "type": "string",
+          "description": "Defined by `name` property of https://w3id.org/openbadges#Profile"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Defined by `url` property of https://w3id.org/openbadges#Profile"
+        },
+        "telephone": {
+          "type": "string",
+          "description": "Defined by `telephone` property of https://w3id.org/openbadges#Profile"
+        },
+        "description": {
+          "type": "string",
+          "description": "Defined by `description` property of https://w3id.org/openbadges#Profile"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageUri",
+          "description": "Defined by `image` property of https://w3id.org/openbadges#Profile"
+        },
+        "email": {
+          "type": "string",
+          "description": "Defined by `email` property of https://w3id.org/openbadges#Profile"
+        },
+        "revocationList": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Defined by `revocationList` property of https://w3id.org/openbadges#Profile. If embedded in a Blockcert and the issuer-hosted Profile, the value in the Blockcert should take preference."
+        }
+      },
+      "required": [
+        "id",
+        "type"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/Profile"
+    }
+  ],
+  "properties": {
+    "publicKey": {
+      "type": "array",
+      "description": "Array of CryptographicKey (https://web-payments.org/vocabs/security#Key) references or objects. Entries may be dereferencable URIs of a document describing a CryptographicKey, or an embedded description of a CryptographicKey.",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string",
+            "description": "Cryptographic key"
+          },
+          {
+            "$ref": "#/definitions/CryptographicKey"
+          }
+        ]
+      }
+    },
+    "introductionURL": {
+      "type": "string",
+      "format": "uri",
+      "description": "Blockcerts extension: URI where potential recipients (or their agents) should submit introductions, including recipient public key. If the issuer supports certificate wallet introductions, this field should specify the endpoint for use by certificate wallets. Otherwise, it can represent a URI enabling some other form of introduction; for example an HTTP IRI for a web form that to be filled out by the recipient."
+    }
+  },
+  "required": [
+    "id",
+    "type",
+    "name",
+    "url"
+  ]
+}

--- a/schema/2.1/merkleProof2017Schema.json
+++ b/schema/2.1/merkleProof2017Schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "MerkleProof2017 schema",
+  "description": "An extension that allows an issuer to issue an Open Badge on the blockchain and provide proof of inclusion in a blockchain transaction.This uses the 2017 Merkle Proof Signature Suite (https://w3c-dvcg.github.io/lds-merkleproof2017/)",
+  "type": "object",
+  "definitions": {
+    "JsonLdType": {
+      "description": "A type or an array of types defined in a JSON-LD context file.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  },	
+  "properties": {
+    "type": {
+      "$ref": "#/definitions/JsonLdType"
+    },
+    "merkleRoot": {
+      "type": "string"
+    },
+    "targetHash": {
+      "type": "string"
+    },
+    "proof": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "right": {
+            "type": "string"
+          },
+          "left": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "anchors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "sourceId": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "chain": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "required": ["type", "merkleRoot", "targetHash", "proof", "anchors"]
+}

--- a/schema/2.1/obi.json
+++ b/schema/2.1/obi.json
@@ -1,0 +1,201 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "extensions": "https://w3id.org/openbadges/extensions#",
+    "obi": "https://w3id.org/openbadges#",
+    "validation": "obi:validation",
+    "cred": "https://w3id.org/credentials#",
+    "dc": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+    "sec": "https://w3id.org/security#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "AlignmentObject": "schema:AlignmentObject",
+    "CryptographicKey": "sec:Key",
+    "Endorsement": "cred:Credential",
+    "Assertion": "obi:Assertion",
+    "BadgeClass": "obi:BadgeClass",
+    "Criteria": "obi:Criteria",
+    "Evidence": "obi:Evidence",
+    "Extension": "obi:Extension",
+    "FrameValidation": "obi:FrameValidation",
+    "IdentityObject": "obi:IdentityObject",
+    "Image": "obi:Image",
+    "HostedBadge": "obi:HostedBadge",
+    "hosted": "obi:HostedBadge",
+    "Issuer": "obi:Issuer",
+    "Profile": "obi:Profile",
+    "RevocationList": "obi:RevocationList",
+    "SignedBadge": "obi:SignedBadge",
+    "signed": "obi:SignedBadge",
+    "TypeValidation": "obi:TypeValidation",
+    "VerificationObject": "obi:VerificationObject",
+    "author": {
+      "@id": "schema:author",
+      "@type": "@id"
+    },
+    "caption": {
+      "@id": "schema:caption"
+    },
+    "claim": {
+      "@id": "cred:claim",
+      "@type": "@id"
+    },
+    "created": {
+      "@id": "dc:created",
+      "@type": "xsd:dateTime"
+    },
+    "creator": {
+      "@id": "dc:creator",
+      "@type": "@id"
+    },
+    "description": {
+      "@id": "schema:description"
+    },
+    "email": {
+      "@id": "schema:email"
+    },
+    "endorsement": {
+      "@id": "cred:credential",
+      "@type": "@id"
+    },
+    "expires": {
+      "@id": "sec:expiration",
+      "@type": "xsd:dateTime"
+    },
+    "genre": {
+      "@id": "schema:genre"
+    },
+    "image": {
+      "@id": "schema:image",
+      "@type": "@id"
+    },
+    "name": {
+      "@id": "schema:name"
+    },
+    "owner": {
+      "@id": "sec:owner",
+      "@type": "@id"
+    },
+    "publicKey": {
+      "@id": "sec:publicKey",
+      "@type": "@id"
+    },
+    "publicKeyPem": {
+      "@id": "sec:publicKeyPem"
+    },
+    "related": {
+      "@id": "dc:relation",
+      "@type": "@id"
+    },
+    "startsWith": {
+      "@id": "http://purl.org/dqm-vocabulary/v1/dqm#startsWith"
+    },
+    "tags": {
+      "@id": "schema:keywords"
+    },
+    "targetDescription": {
+      "@id": "schema:targetDescription"
+    },
+    "targetFramework": {
+      "@id": "schema:targetFramework"
+    },
+    "targetName": {
+      "@id": "schema:targetName"
+    },
+    "targetUrl": {
+      "@id": "schema:targetUrl"
+    },
+    "telephone": {
+      "@id": "schema:telephone"
+    },
+    "url": {
+      "@id": "schema:url",
+      "@type": "@id"
+    },
+    "version": {
+      "@id": "schema:version"
+    },
+    "alignment": {
+      "@id": "obi:alignment",
+      "@type": "@id"
+    },
+    "allowedOrigins": {
+      "@id": "obi:allowedOrigins"
+    },
+    "audience": {
+      "@id": "obi:audience"
+    },
+    "badge": {
+      "@id": "obi:badge",
+      "@type": "@id"
+    },
+    "criteria": {
+      "@id": "obi:criteria",
+      "@type": "@id"
+    },
+    "endorsementComment": {
+      "@id": "obi:endorsementComment"
+    },
+    "evidence": {
+      "@id": "obi:evidence",
+      "@type": "@id"
+    },
+    "hashed": {
+      "@id": "obi:hashed",
+      "@type": "xsd:boolean"
+    },
+    "identity": {
+      "@id": "obi:identityHash"
+    },
+    "issuedOn": {
+      "@id": "obi:issueDate",
+      "@type": "xsd:dateTime"
+    },
+    "issuer": {
+      "@id": "obi:issuer",
+      "@type": "@id"
+    },
+    "narrative": {
+      "@id": "obi:narrative"
+    },
+    "recipient": {
+      "@id": "obi:recipient",
+      "@type": "@id"
+    },
+    "revocationList": {
+      "@id": "obi:revocationList",
+      "@type": "@id"
+    },
+    "revocationReason": {
+      "@id": "obi:revocationReason"
+    },
+    "revoked": {
+      "@id": "obi:revoked",
+      "@type": "xsd:boolean"
+    },
+    "revokedAssertions": {
+      "@id": "obi:revoked"
+    },
+    "salt": {
+      "@id": "obi:salt"
+    },
+    "targetCode": {
+      "@id": "obi:targetCode"
+    },
+    "uid": {
+      "@id": "obi:uid"
+    },
+    "validatesType": "obi:validatesType",
+    "validationFrame": "obi:validationFrame",
+    "validationSchema": "obi:validationSchema",
+    "verification": {
+      "@id": "obi:verify",
+      "@type": "@id"
+    },
+    "verificationProperty": {
+      "@id": "obi:verificationProperty"
+    },
+    "verify": "verification"
+  }
+}

--- a/schema/2.1/recipientSchema.json
+++ b/schema/2.1/recipientSchema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "RecipientProfile schema",
+  "description": "A Blockcerts extension allowing inclusion of additional recipient details, including recipient publicKey and name. Inclusion of the recipient publicKey allows the recipient to make a strong claim of ownership over the key, and hence the badge being awarded. In the future, publicKey will be deprecated in favor of a decentralized id (DID) in the `id` field.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "reserved for future use as DID"
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of recipient, http://schema.org/name"
+    },
+    "publicKey": {
+      "type": "string",
+      "format": "uri",
+      "description": "In Blockcerts `publicKey` IRIs are typically represented with a `<scheme>:` prefix. For Bitcoin transactions, this would be the recipient public Bitcoin address prefixed with `ecdsa-koblitz-pubkey:`; e.g. `ecdsa-koblitz-pubkey:14RZvYazz9H2DC2skBfpPVxax54g4yabxe`"
+    }
+  }
+}
+
+

--- a/schema/2.1/schema.json
+++ b/schema/2.1/schema.json
@@ -1,0 +1,325 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Assertion schema",
+  "description": "Blockcerts 2.1 Assertion schema. Extends Open Badges v2.0 schema: https://w3id.org/openbadges#Assertion",
+  "type": "object",
+  "definitions": {
+    "JsonLdContext": {
+      "description": "A link to a valid JSON-LD context, or array of JSON-LD contexts",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "array"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "JsonLdType": {
+      "description": "A type or an array of types defined in a referenced JSON-LD context.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "DateTime": {
+      "description": "Open Badges must express timestamps as strings compatible with ISO 8601 guidelines, including the time and a time zone indicator. It is recommended to publish all timestamps in UTC. Previous versions of Open Badges allowed Unix timestamps as integers. Open Badges v2.0 requires string ISO 8601 values with time zone indicators. For example, 2016-12-31T23:59:59+00:00 is a valid ISO 8601 timestamp. It contains the year, month, day, T separator, hour number 0-23, minute, optional seconds and decimal microsecond, and a time zone indicator (+/- an offset from UTC or the Z designator for UTC).",
+      "type": "string"
+    },
+    "HashString": {
+      "type": "string",
+      "description": "Open Badges SHA-256 Hash",
+      "pattern": "^sha256\\$[a-fA-F0-9]{64}$"
+
+    },
+    "IdentityObject": {
+      "title": "Badge Identity Object",
+      "description": "From https://w3id.org/openbadges#IdentityObject.",
+      "type": "object",
+      "properties": {
+        "identity": {
+          "description": "Defined by `identity` property of https://w3id.org/openbadges#IdentityObject",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/HashString"
+            },
+            {
+              "type": "string",
+              "format": "email"
+            }
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "email"
+          ],
+          "description": "Defined by `type` property of https://w3id.org/openbadges#IdentityObject"
+        },
+        "hashed": {
+          "type": "boolean",
+          "description": "Defined by `hashed` property of https://w3id.org/openbadges#IdentityObject"
+        },
+        "salt": {
+          "description": "Defined by `salt` property of https://w3id.org/openbadges#IdentityObject",
+          "anyOf": [ 
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "identity",
+        "type",
+        "hashed"
+      ]
+    },
+    "VerificationObject": {
+      "description": "From https://w3id.org/openbadges#VerificationObject, with extensions for Blockcerts verification",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/JsonLdType",
+          "description": "Defined by `type` property of https://w3id.org/openbadges#VerificationObject. Blockcerts extension: this should contain the entry `MerkleProofVerification2017`"
+        },
+        "publicKey": {
+          "type": "string",
+          "anyOf": [{
+            "type": "string",
+            "pattern": "^ecdsa-koblitz-pubkey:",
+            "description": "Issuer public key or blockchain address with `<scheme>:` prefix. For Bitcoin transactions, this would be the issuer public address prefixed with `ecdsa-koblitz-pubkey:`. Example: `ecdsa-koblitz-pubkey:14RZvYazz9H2DC2skBfpPVxax54g4yabxe`"
+          }, {
+            "type": "string"
+          }
+          ],
+          "description": "Blockcerts extension: the expected blockchain address for the signer of the transaction containing the merkle proof. In Blockcerts `publicKey`s are typically represented with a `<scheme>:` prefix. For Bitcoin transactions, this would be the issuer public Bitcoin address prefixed with `ecdsa-koblitz-pubkey:`; e.g. `ecdsa-koblitz-pubkey:14RZvYazz9H2DC2skBfpPVxax54g4yabxe`"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ImageUri": {
+      "description": "An image representative of the entity. In Blockcerts this is typically a data URI (https://en.wikipedia.org/wiki/Data_URI_scheme) embedded as a base-64 encoded PNG image, but it may also be a URI where the image may be found.",
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^data:"
+        },
+        {
+          "type": "string",
+          "format": "uri"
+        }
+      ]
+    },
+    "AlignmentObject": {
+      "description": "From https://w3id.org/openbadges#AlignmentObject",
+      "type": "object",
+      "properties": {
+        "targetName": {
+          "type": "string",
+          "description": "Defined by `targetName` property of https://w3id.org/openbadges#AlignmentObject"
+        },
+        "targetUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Defined by `targetUrl` property of https://w3id.org/openbadges#AlignmentObject"
+        },
+        "targetDescription": {
+          "type": "string",
+          "description": "Defined by `targetDescription` property of https://w3id.org/openbadges#AlignmentObject"
+        }
+      },
+      "required": [
+        "targetName",
+        "targetUrl"
+      ]
+    },
+    "AlignmentArray": {
+      "description": "List of objects describing which objectives or educational standards this badge aligns to, if any.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AlignmentObject"
+      }
+    },
+    "TagsArray": {
+      "description": "List of tags that describe the type of achievement.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "SignatureLine": {
+      "$ref": "https://w3id.org/blockcerts/schema/2.1/signatureLineSchema.json"
+    },
+    "RecipientProfile": {
+      "$ref": "https://w3id.org/blockcerts/schema/2.1/recipientSchema.json"
+    },
+    "MerkleProof2017": {
+      "$ref": "https://w3id.org/blockcerts/schema/2.1/merkleProof2017Schema.json"
+    },
+    "BadgeClass": {
+      "description": "From https://w3id.org/openbadges#BadgeClass",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri",
+          "description": "Defined by `id` property of https://w3id.org/openbadges#BadgeClass. This field is now required in V2. This may be an HTTP IRI, but only if the issuer plans to host the BadgeClass definitions on a long-term basis, or (at least) until expiration of certificates referencing this BadgeClass. Otherwise it is recommended to use a `urn:uuid:<UUID>`-formatted IRI."
+        },
+        "type": {
+          "$ref": "#/definitions/JsonLdType",
+          "description": "Defined by `type` property of https://w3id.org/openbadges#BadgeClass"
+        },
+        "name": {
+          "type": "string",
+          "description": "Defined by `name` property of https://w3id.org/openbadges#BadgeClass"
+        },
+        "subtitle": {
+          "type": "string",
+          "description": "Blockcerts extension: optional subtitle of the certificate"
+        },
+        "description": {
+          "type": "string",
+          "description": "Defined by `description` property of https://w3id.org/openbadges#BadgeClass"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageUri",
+          "description": "Defined by `image` property of https://w3id.org/openbadges#BadgeClass"
+        },
+        "criteria": {
+          "type": "object",
+          "description": "Defined by `criteria` property of https://w3id.org/openbadges#BadgeClass. This field is required in Open Badges. If migrating from an earlier version, a quick change is to reuse the `description` field"
+        },
+        "issuer": {
+          "$ref": "https://w3id.org/blockcerts/schema/2.1/issuerSchema.json",
+          "description": "Defined by `issuer` property of https://w3id.org/openbadges#BadgeClass, with Blockcerts extensions for blockchain verification of badges."
+        },
+        "alignment": {
+          "$ref": "#/definitions/AlignmentArray",
+          "description": "Defined by `alignment` property of https://w3id.org/openbadges#BadgeClass"
+        },
+        "tags": {
+          "$ref": "#/definitions/TagsArray",
+          "description": "Defined by `tags` property of https://w3id.org/openbadges#BadgeClass"
+        },
+        "signatureLines": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SignatureLine"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SignatureLine"
+              }
+            }
+          ],
+          "description": "Blockcerts extension: array of signature lines for display."
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "description",
+        "image",
+        "issuer",
+        "criteria"
+      ]
+    }
+  },
+  "properties": {
+    "id": {
+      "description": "Defined by `id` property in https://w3id.org/openbadges#Assertion. This may be an HTTP IRI, but only if the issuer plans to host the assertions on a long-term basis, or (at least) until their expiration. Otherwise it is recommended to use a `urn:uuid:<UUID>`-formatted IRI.",
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^urn:uuid:"
+        },
+        {
+          "type": "string",
+          "format": "uri"
+        }
+      ]
+    },
+    "type": {
+      "$ref": "#/definitions/JsonLdType",
+      "description": "Defined by `type` property of https://w3id.org/openbadges#Assertion"
+    },
+    "recipient": {
+      "$ref": "#/definitions/IdentityObject",
+      "description": "Defined by `recipient` property of https://w3id.org/openbadges#Assertion, with Blockcerts extensions for recipient proof of ownership."
+    },
+    "badge": {
+      "$ref": "#/definitions/BadgeClass",
+      "description": "Defined by `badge` property of https://w3id.org/openbadges#Assertion, with Blockcerts extensions for (display) signature images."
+    },
+    "verification": {
+      "$ref": "#/definitions/VerificationObject",
+      "description": "Defined by `verification` property of https://w3id.org/openbadges#Assertion, with Blockcerts extensions for verification of badges on a blockchain."
+    },
+    "issuedOn": {
+      "$ref": "#/definitions/DateTime",
+      "description": "Defined by `issuedOn` property of https://w3id.org/openbadges#Assertion"
+    },
+    "image": {
+      "$ref": "#/definitions/ImageUri",
+      "description": "Defined by `image` property of https://w3id.org/openbadges#Assertion"
+    },
+    "evidence": {
+      "type": "string",
+      "format": "uri",
+      "description": "Defined by `evidence` property of https://w3id.org/openbadges#Assertion"
+    },
+    "narrative": {
+      "type": "string",
+      "description": "Defined by `narrative` property of https://w3id.org/openbadges#Assertion"
+    },
+    "expires": {
+      "$ref": "#/definitions/DateTime",
+      "description": "Defined by `expires` property of https://w3id.org/openbadges#Assertion"
+    },
+    "recipientProfile": {
+      "$ref": "#/definitions/RecipientProfile"
+    },
+    "signature": {
+      "$ref": "#/definitions/MerkleProof2017"
+    }
+  },
+  "required": [
+    "id",
+    "type",
+    "recipient",
+    "badge",
+    "verification",
+    "issuedOn"
+  ],
+  "additionalProperties": true
+}

--- a/schema/2.1/signatureLineSchema.json
+++ b/schema/2.1/signatureLineSchema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "SignatureLine schema",
+  "description": "An extension that allows issuers to add signature lines to the visual representation of the badge. This is not part of the cryptographic proof; it is for display purposes only.",
+  "type": "object",
+  "definitions": {
+    "ImageUri": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "data:image/png;base64,",
+          "description": "An image representative of the entity. In Blockcerts this is typically a data URI (https://en.wikipedia.org/wiki/Data_URI_scheme) embedded as a base-64 encoded PNG image, but it may also be a URI where the image may be found."
+        },
+        {
+          "type": "string",
+          "format": "uri",
+          "description": "IRI (typically HTTP) representing this signature image."
+        }
+      ]      
+    }
+  },
+  "properties": {
+    "image": {
+      "$ref": "#/definitions/ImageUri"
+    },
+    "jobTitle": {
+      "type": "string",
+      "description": "Job title of signer, http://schema.org/jobTitle"
+    },
+    "name": {
+      "type": "string",
+      "description": "Full name of signer, http://schema.org/name"
+    }
+  },
+  "required": ["image"]
+}


### PR DESCRIPTION
There are no vocabulary changes here, strictly speaking, but this allows some verifiers to determine that Open Badges hosted verification is supported in a first-class way at verification time.